### PR TITLE
Fix bug where multiple instances couldnt be started and options werent supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TelemetryMetricsSplunk
 
+[![Version](https://img.shields.io/hexpm/v/req.svg)](https://hex.pm/packages/req)
+
 :rotating_light: This library is in alpha :rotating_light:
 
 `Telemetry.Metrics` reporter for Splunk metrics indexes using the Splunk HTTP Event Collector (HEC).
@@ -33,7 +35,7 @@ Add `telemetry_metrics_splunk` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:telemetry_metrics_splunk, "0.0.3-alpha"}
+    {:telemetry_metrics_splunk, "~> 0.0.0"}
   ]
 end
 ```

--- a/lib/telemetry_metrics_splunk.ex
+++ b/lib/telemetry_metrics_splunk.ex
@@ -59,7 +59,8 @@ defmodule TelemetryMetricsSplunk do
 
   @options_schema [
     finch: [
-      type: :atom
+      type: {:or, [:atom, :nil]},
+      required: false
     ],
     metrics: [
       type:
@@ -75,10 +76,12 @@ defmodule TelemetryMetricsSplunk do
       required: true
     ],
     token: [
-      type: :string
+      type: {:or, [:string, :nil]},
+      required: false
     ],
     url: [
-      type: :string
+      type: {:or, [:string, :nil]},
+      required: false
     ]
   ]
 
@@ -125,7 +128,7 @@ defmodule TelemetryMetricsSplunk do
   """
   @spec start_link(options :: options()) :: GenServer.on_start()
   def start_link(options) do
-    GenServer.start_link(__MODULE__, options, name: __MODULE__)
+    GenServer.start_link(__MODULE__, options)
   end
 
   @impl GenServer

--- a/lib/telemetry_metrics_splunk/hec/api.ex
+++ b/lib/telemetry_metrics_splunk/hec/api.ex
@@ -27,13 +27,33 @@ defmodule TelemetryMetricsSplunk.Hec.Api do
 
   require Logger
 
-  @type options :: [finch: Finch.name(), token: String.t(), url: String.t()]
+  @type options :: [finch: Finch.name() | nil, token: String.t() | nil, url: String.t() | nil]
 
   @doc """
   Sends metrics to the Splunk HTTP Event Collector (HEC).
+
+  If `finch`, `token`, or `url` are `nil`, the function will log the info and not send the metrics.
   """
   @spec send(measurements :: map(), options :: options(), metadata :: map()) :: :ok
   def send(measurements, options, metadata \\ %{})
+
+  def send(measurements, [finch: _finch, token: nil, url: _url], metadata) do
+    send(measurements, [finch: nil, token: nil, url: nil], metadata)
+  end
+
+  def send(measurements, [finch: _finch, token: _token, url: nil], metadata) do
+    send(measurements, [finch: nil, token: nil, url: nil], metadata)
+  end
+
+  def send(measurements, [finch: nil, token: _token, url: _url], metadata) do
+    send(measurements, [finch: nil, token: nil, url: nil], metadata)
+  end
+
+  def send(measurements, [finch: nil, token: nil, url: nil], metadata) do
+    create_payload(measurements, metadata)
+    |> Map.put(:module, __MODULE__)
+    |> Logger.info()
+  end
 
   def send(measurements, [finch: finch, token: token, url: url], metadata) do
     data = create_payload(measurements, metadata) |> Jason.encode!()
@@ -52,12 +72,6 @@ defmodule TelemetryMetricsSplunk.Hec.Api do
       {:error, reason} ->
         Logger.error(%{module: __MODULE__, reason: reason})
     end
-  end
-
-  def send(measurements, _options, metadata) do
-    create_payload(measurements, metadata)
-    |> Map.put(:module, __MODULE__)
-    |> Logger.info()
   end
 
   defp create_payload(measurements, metadata) do


### PR DESCRIPTION
My nimble options were wrong, required = false != allowing nil. Also, by adding a name to the instance being started, it only allowed once instance to be started. This PR fixes both of those bugs.