### PR TITLE
Allow test deps at runtime

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,10 +36,10 @@ defmodule TelemetryMetricsSplunk.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:bypass, "2.1.0", only: [:test], runtime: false},
+      {:bypass, "2.1.0", only: [:test]},
       {:credo, "1.7.5", only: [:dev], runtime: false},
       {:ex_doc, "0.32.0", only: [:dev], runtime: false},
-      {:excoveralls, "0.18.1", only: [:test], runtime: false},
+      {:excoveralls, "0.18.1", only: [:test]},
       {:finch, "~> 0.18"},
       {:dialyxir, "1.4.3", only: [:dev], runtime: false},
       {:jason, "~> 1.4"},


### PR DESCRIPTION
We need to allow these deps at runtime to be used in the test env.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0f0b835f6a3c706edb9846146dd0004fea3f81f3  | 
|--------|--------|

### Summary:
This PR updates the `mix.exs` to allow `:bypass` and `:excoveralls` dependencies to be available at runtime in the test environment by removing the `runtime: false` restriction.

**Key points**:
- Updated `mix.exs` in `TelemetryMetricsSplunk.MixProject`.
- Modified `:bypass` and `:excoveralls` dependencies to be available at runtime in test environment.
- Removed `runtime: false` from these dependencies.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->